### PR TITLE
Added second argument to constructor to override settings + custom onClick and font color values.

### DIFF
--- a/javascript/effects/wordle-tag-cloud/js/Wordle.js
+++ b/javascript/effects/wordle-tag-cloud/js/Wordle.js
@@ -220,7 +220,6 @@ var WORDLEJS = WORDLEJS || {};
             curIdx: 0,
             keepCenter: false,
             urlPrefix: 'http://google.com/search?q=',
-            balance: false
         },
 
         //methods

--- a/javascript/effects/wordle-tag-cloud/js/Wordle.js
+++ b/javascript/effects/wordle-tag-cloud/js/Wordle.js
@@ -243,8 +243,8 @@ var WORDLEJS = WORDLEJS || {};
                     weight: wordObject.count,
                     url: urlPrefix + wordObject.text,
                     //strokeColor: Random.getRandomColor(), //no use
-                    fillColor: Random.getRandomColor(0x44, 0xff),
-                    fontFamily: wordObject.color ? wordObject.color : Random.getRandomBoolean() ? 'sans-serif' : 'serif',
+                    fillColor: wordObject.color ? wordObject.color : Random.getRandomColor(0x44, 0xff),
+                    fontFamily: Random.getRandomBoolean() ? 'sans-serif' : 'serif',
                     onClick: wordObject.onclick,
                     rotated: this.allowRotate && Random.getRandomBoolean() // half chances of rotation if allowRotate is true
                 };

--- a/javascript/effects/wordle-tag-cloud/js/Wordle.js
+++ b/javascript/effects/wordle-tag-cloud/js/Wordle.js
@@ -69,6 +69,7 @@ var WORDLEJS = WORDLEJS || {};
         this.fillColor = initObj.fillColor; //Color
         this.strokeColor = initObj.strokeColor; //Color
         this.url = initObj.url;
+        this.onClick = initObj.onClick;
 
         this.sprite = null; //considered later
         this.bounds = null; //bounds of the rendered text
@@ -130,6 +131,15 @@ var WORDLEJS = WORDLEJS || {};
             anchor.target = '_blank';
             anchor.textContent = text;
             anchor.className = 'word';
+
+            var self = this;
+            if (this.onClick) {
+                anchor.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    return self.onClick.call(self, e);
+                });
+            }
+
             s.color = '#' + fillColor;
             s.font = 'normal normal ' + this.fontSize + 'px/' + this.fontSize + 'px ' + this.fontFamily;
             
@@ -168,12 +178,21 @@ var WORDLEJS = WORDLEJS || {};
     /*
      * Wordle class
      */
-    WORDLEJS.Wordle = function (elContainer) {
+    WORDLEJS.Wordle = function (elContainer, options) {
         var container = document.createElement('div');
         container.className = 'wordle';
         elContainer.appendChild(container);
         
         var canvas = document.createElement('canvas');
+
+        options = options || {};
+        for (var key in this.defaultSettings) {
+            if (options.hasOwnProperty(key)) {
+                this[key] = options[key];
+            } else {
+                this[key] = this.defaultSettings[key];
+            }
+        }
 
         this.ctx = canvas.getContext('2d'); //canvas used to measure text only
         this.parent = elContainer;
@@ -182,24 +201,27 @@ var WORDLEJS = WORDLEJS || {};
 
     WORDLEJS.Wordle.prototype = {
         //member
-        biggestSize: 80,
-        smallestSize: 12,
-        words: null,
-        dRadius: 10.0,
-        dDeg: 10,
-        sortType: '', 
-        allowRotate: true,
-        ctx: null,
-        container: null,
-        center: null,
-        current: null,
-        first: null,
-        wl: 0,
-        startTime: 0,
-        runTime: 0,
-        curIdx: 0,
-        keepCenter: false,
-        urlPrefix: 'http://google.com/search?q=',
+        defaultSettings: {
+            biggestSize: 80,
+            smallestSize: 12,
+            words: null,
+            dRadius: 10.0,
+            dDeg: 10,
+            sortType: '',
+            allowRotate: true,
+            ctx: null,
+            container: null,
+            center: null,
+            current: null,
+            first: null,
+            wl: 0,
+            startTime: 0,
+            runTime: 0,
+            curIdx: 0,
+            keepCenter: false,
+            urlPrefix: 'http://google.com/search?q=',
+            balance: false
+        },
 
         //methods
         constructor: WORDLEJS.Wordle,
@@ -223,8 +245,9 @@ var WORDLEJS = WORDLEJS || {};
                     url: urlPrefix + wordObject.text,
                     //strokeColor: Random.getRandomColor(), //no use
                     fillColor: Random.getRandomColor(0x44, 0xff),
-                    fontFamily: Random.getRandomBoolean() ? 'sans-serif' : 'serif',
-                    rotated: Random.getRandomBoolean() // half chances of rotation
+                    fontFamily: wordObject.color ? wordObject.color : Random.getRandomBoolean() ? 'sans-serif' : 'serif',
+                    onClick: wordObject.onclick,
+                    rotated: this.allowRotate && Random.getRandomBoolean() // half chances of rotation if allowRotate is true
                 };
 
                 this.words.push(new WORDLEJS.Word(w));

--- a/javascript/effects/wordle-tag-cloud/js/Wordle.js
+++ b/javascript/effects/wordle-tag-cloud/js/Wordle.js
@@ -140,7 +140,7 @@ var WORDLEJS = WORDLEJS || {};
                 });
             }
 
-            s.color = '#' + fillColor;
+            s.color = '#' + fillColor.replace(/^#/, '');
             s.font = 'normal normal ' + this.fontSize + 'px/' + this.fontSize + 'px ' + this.fontFamily;
             
             if (this._rotated) {


### PR DESCRIPTION
Hey there!

I've recently found your library on the web while searching for a Wordle implementation in JavaScript. Awesome job, I must say!

But I was lacking some things that I decided to suggest to merge into master. That is:
- Ability to override settings without changing the sources, e.g.:
  
  ``` js
  var wordle = new WORDLEJS.Wordle(document.getElementById('tags'), {
      allowRotate: false,
      keepCenter: true,
      biggestSize: Math.min(window.innerWidth, window.innerHeight) / 20,
      smallestSize: Math.min(window.innerWidth, window.innerHeight) / 40,
      sortType: 'a',
      balance: true
  });
  ```
- Implemented missing functionality for `allowRotate` option (which was previously ignored)
- Added `color` option to word objects to force using particular color;
- Added `onclick` option to set custom onclick handlers for words.

Great job developing this library! It helped me **really** a lot ;)

Regards,
Andrew
